### PR TITLE
remove AWS::CodeStarNotifications::NotificationRule

### DIFF
--- a/lib/supportedTypes.js
+++ b/lib/supportedTypes.js
@@ -25,7 +25,6 @@ const SUPPORTED_TYPES_MAP_TAGS = [
   'AWS::ApiGatewayV2::DomainName',
   'AWS::ApiGatewayV2::Stage',
   'AWS::ApiGatewayV2::VpcLink',
-  'AWS::CodeStarNotifications::NotificationRule',
   'AWS::Cognito::UserPool',
   'AWS::EKS::Nodegroup',
   'AWS::Glue::Crawler',

--- a/test/fixtures/index.js
+++ b/test/fixtures/index.js
@@ -50,7 +50,6 @@ const PLUGIN_DEFAULT_CONFIG = {
     'AWS::ApiGatewayV2::DomainName',
     'AWS::ApiGatewayV2::Stage',
     'AWS::ApiGatewayV2::VpcLink',
-    'AWS::CodeStarNotifications::NotificationRule',
     'AWS::Cognito::UserPool',
     'AWS::EKS::Nodegroup',
     'AWS::Glue::Crawler',


### PR DESCRIPTION
This resource type has an "Update requires: [Replacement](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-replacement)"